### PR TITLE
Add `exit` and `report_exception` syscalls.

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,52 @@
+//! Interacting with debugging agent
+
+pub enum Exception {
+    // Hardware reason codes
+    BranchThroughZero = 0x20000,
+    UndefinedInstr = 0x20001,
+    SoftwareInterrupt = 0x20002,
+    PrefetchAbort = 0x20003,
+    DataAbort = 0x20004,
+    AddressException = 0x20005,
+    IRQ = 0x20006,
+    FIQ = 0x20007,
+    // Software reason codes
+    BreakPoint = 0x20020,
+    WatchPoint = 0x20021,
+    StepComplete = 0x20022,
+    RunTimeErrorUnknown = 0x20023,
+    InternalError = 0x20024,
+    UserInterruption = 0x20025,
+    ApplicationExit = 0x20026,
+    StackOverflow = 0x20027,
+    DivisionByZero = 0x20028,
+    OSSpecific = 0x20029,
+}
+
+/// Reports to the debugger that the execution has completed.
+///
+/// If `status` is not 0 then an error is reported.
+/// This call may not return.
+///
+pub fn exit(status: i8) {
+    if status == 0 {
+        report_exception(Exception::ApplicationExit);
+    } else {
+        report_exception(Exception::RunTimeErrorUnknown);
+    }
+}
+
+/// Report an exception to the debugger directly.
+///
+/// This call may not return.
+///
+/// # Arguments
+///
+/// * `reason` - A reason code reported back to the debugger
+///
+pub fn report_exception(reason: Exception) {
+    let code = reason as usize;
+    unsafe {
+        syscall!(REPORT_EXCEPTION, code);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! Target program:
 //!
-//! ```
+//! ```rust,ignore
 //! fn main() {
 //!     // File descriptor (on the host)
 //!     const STDOUT: usize = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,10 @@
 //!
 //! Target program:
 //!
-//! ```rust,ignore
+//! ```
+//! #[macro_use]
+//! extern crate cortex_m_semihosting;
+//!
 //! fn main() {
 //!     // File descriptor (on the host)
 //!     const STDOUT: usize = 1;
@@ -112,10 +115,10 @@ pub mod io;
 pub mod nr;
 pub mod debug;
 
-/// Performs a semihosting operation
+/// Performs a semihosting operation, takes a pointer to an argument block
 #[inline(always)]
 #[cfg(target_arch = "arm")]
-pub unsafe fn syscall<T: Sized>(mut nr: usize, arg: T) -> usize {
+pub unsafe fn syscall<T>(mut nr: usize, arg: &T) -> usize {
     asm!("bkpt 0xAB"
          : "+{r0}"(nr)
          : "{r1}"(arg)
@@ -124,7 +127,26 @@ pub unsafe fn syscall<T: Sized>(mut nr: usize, arg: T) -> usize {
     nr
 }
 
+/// Performs a semihosting operation, takes a pointer to an argument block
 #[cfg(not(target_arch = "arm"))]
-pub unsafe fn syscall<T: Sized>(_nr: usize, _arg: T) -> usize {
+pub unsafe fn syscall<T>(_nr: usize, _arg: &T) -> usize {
+    0
+}
+
+/// Performs a semihosting operation, takes one integer as an argument
+#[inline(always)]
+#[cfg(target_arch = "arm")]
+pub unsafe fn syscall1(mut nr: usize, arg: usize) -> usize {
+    asm!("bkpt 0xAB"
+         : "+{r0}"(nr)
+         : "{r1}"(arg)
+         : "memory"
+         : "volatile");
+    nr
+}
+
+/// Performs a semihosting operation, takes one integer as an argument
+#[cfg(not(target_arch = "arm"))]
+pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
     0
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,11 +110,12 @@ mod macros;
 
 pub mod io;
 pub mod nr;
+pub mod debug;
 
 /// Performs a semihosting operation
 #[inline(always)]
 #[cfg(target_arch = "arm")]
-pub unsafe fn syscall<T>(mut nr: usize, arg: &T) -> usize {
+pub unsafe fn syscall<T: Sized>(mut nr: usize, arg: T) -> usize {
     asm!("bkpt 0xAB"
          : "+{r0}"(nr)
          : "{r1}"(arg)
@@ -124,6 +125,6 @@ pub unsafe fn syscall<T>(mut nr: usize, arg: &T) -> usize {
 }
 
 #[cfg(not(target_arch = "arm"))]
-pub unsafe fn syscall<T>(_nr: usize, _arg: &T) -> usize {
+pub unsafe fn syscall<T: Sized>(_nr: usize, _arg: T) -> usize {
     0
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,11 @@
 /// Variable argument version of `syscall`
 #[macro_export]
 macro_rules! syscall {
+    ($nr:ident) => {
+        $crate::syscall($crate::nr::$nr, 0usize)
+    };
     ($nr:ident, $a1:expr) => {
-        $crate::syscall($crate::nr::$nr, &($a1 as usize))
+        $crate::syscall($crate::nr::$nr, $a1 as usize)
     };
     ($nr:ident, $a1:expr, $a2:expr) => {
         $crate::syscall($crate::nr::$nr, &[$a1 as usize, $a2 as usize])

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 /// Variable argument version of `syscall`
 #[macro_export]
 macro_rules! syscall {
-    ($nr:ident, $a1:expr, $a2:expr) => {
+    ($nr:ident, $a1:expr) => {
         $crate::syscall($crate::nr::$nr, &($a1 as usize))
     };
     ($nr:ident, $a1:expr, $a2:expr) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,10 +2,10 @@
 #[macro_export]
 macro_rules! syscall {
     ($nr:ident) => {
-        $crate::syscall($crate::nr::$nr, 0usize)
+        $crate::syscall1($crate::nr::$nr, 0)
     };
     ($nr:ident, $a1:expr) => {
-        $crate::syscall($crate::nr::$nr, $a1 as usize)
+        $crate::syscall($crate::nr::$nr, &[$a1 as usize])
     };
     ($nr:ident, $a1:expr, $a2:expr) => {
         $crate::syscall($crate::nr::$nr, &[$a1 as usize, $a2 as usize])
@@ -17,6 +17,14 @@ macro_rules! syscall {
     ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr) => {
         $crate::syscall($crate::nr::$nr, &[$a1 as usize, $a2 as usize,
                                            $a3 as usize, $a4 as usize])
+    };
+}
+
+/// Macro version of `syscall1`
+#[macro_export]
+macro_rules! syscall1 {
+    ($nr:ident, $a1:expr) => {
+        $crate::syscall1($crate::nr::$nr, $a1 as usize)
     };
 }
 

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -22,3 +22,5 @@ pub const TMPNAM: usize = 0x0d;
 pub const WRITE0: usize = 0x04;
 pub const WRITE: usize = 0x05;
 pub const WRITEC: usize = 0x03;
+pub const ENTER_SVC: usize = 0x17;
+pub const REPORT_EXCEPTION: usize = 0x18;


### PR DESCRIPTION
This calls can be used to notify the debugging agent that some exception has occurred or that the program has finished executing.

Please note that I changed syscall interface to also accept integers, not just pointers. Converting arbitary numbers to pointers does not seem like a good idea.