### PR TITLE
Fix crash in write_all if syscall fails

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -13,74 +13,76 @@ struct Stderr;
 /// Host's standard output
 struct Stdout;
 
-fn write_all(fd: usize, mut buffer: &[u8]) {
+fn write_all(fd: usize, mut buffer: &[u8]) -> Result<(),()> {
     while !buffer.is_empty() {
         match unsafe { syscall!(WRITE, fd, buffer.as_ptr(), buffer.len()) } {
             // Done
-            0 => return,
+            0 => return Ok(()),
             // `n` bytes were not written
-            n => {
+            n if n <= buffer.len() && n > 0 => {
                 let offset = (buffer.len() - n) as isize;
                 buffer = unsafe {
                     slice::from_raw_parts(buffer.as_ptr().offset(offset as isize), n)
-                }
-            }
+                };
+            },
+            // error writing bytes, most likely write() returned -1
+            _ => return Err(()),
         }
     }
+
+    Ok(())
 }
 
 impl Stderr {
-    fn write_all(&mut self, buffer: &[u8]) {
-        write_all(STDERR, buffer);
+    fn write_all(&mut self, buffer: &[u8]) -> Result<(),()> {
+        write_all(STDERR, buffer)
     }
 }
 
 impl Stdout {
-    fn write_all(&mut self, buffer: &[u8]) {
-        write_all(STDOUT, buffer);
+    fn write_all(&mut self, buffer: &[u8]) -> Result<(), ()> {
+        write_all(STDOUT, buffer)
     }
 }
 
 impl Write for Stderr {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.write_all(s.as_bytes());
-        Ok(())
+        self.write_all(s.as_bytes()).or(Err(fmt::Error))
     }
 }
 
 impl Write for Stdout {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.write_all(s.as_bytes());
-        Ok(())
+        self.write_all(s.as_bytes()).or(Err(fmt::Error))
     }
 }
 
 /// Write a `buffer` to the host's stderr
-pub fn ewrite(buffer: &[u8]) {
+pub fn ewrite(buffer: &[u8]) -> Result<(),()> {
     Stderr.write_all(buffer)
 }
 
 /// Write `fmt::Arguments` to the host's stderr
-pub fn ewrite_fmt(args: fmt::Arguments) {
-    Stderr.write_fmt(args).ok();
+pub fn ewrite_fmt(args: fmt::Arguments) -> fmt::Result {
+    Stderr.write_fmt(args)
 }
 
 /// Write a `string` to the host's stderr
-pub fn ewrite_str(string: &str) {
+pub fn ewrite_str(string: &str) -> Result<(),()> {
     Stderr.write_all(string.as_bytes())
 }
 
 /// Write a `buffer` to the host's stdout
-pub fn write(buffer: &[u8]) {
+pub fn write(buffer: &[u8]) ->Result<(),()> {
     Stdout.write_all(buffer)
 }
 
 /// Write `fmt::Arguments` to the host's stdout
-pub fn write_fmt(args: fmt::Arguments) {
-    Stdout.write_fmt(args).ok();
+pub fn write_fmt(args: fmt::Arguments) -> fmt::Result {
+    Stdout.write_fmt(args)
 }
 
 /// Write a `string` to the host's stdout
-pub fn write_str(string: &str) {
+pub fn write_str(string: &str) -> Result<(),()> {
     Stdout.write_all(string.as_bytes())
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,8 +31,8 @@ macro_rules! syscall1 {
 /// Macro for printing to the **host's** standard stderr
 #[macro_export]
 macro_rules! ehprint {
-    ($s:expr) => ($crate::io::ewrite_str($s));
-    ($($arg:tt)*) => ($crate::io::ewrite_fmt(format_args!($($arg)*)));
+    ($s:expr) => ($crate::io::ewrite_str($s).ok());
+    ($($arg:tt)*) => ($crate::io::ewrite_fmt(format_args!($($arg)*)).ok());
 }
 
 /// Macro for printing to the **host's** standard error, with a newline.
@@ -46,8 +46,8 @@ macro_rules! ehprintln {
 /// Macro for printing to the **host's** standard output
 #[macro_export]
 macro_rules! hprint {
-    ($s:expr) => ($crate::io::write_str($s));
-    ($($arg:tt)*) => ($crate::io::write_fmt(format_args!($($arg)*)));
+    ($s:expr) => ($crate::io::write_str($s).ok());
+    ($($arg:tt)*) => ($crate::io::write_fmt(format_args!($($arg)*)).ok());
 }
 
 /// Macro for printing to the **host's** standard output, with a newline.


### PR DESCRIPTION
This validates the length returned by the write() syscall to make sure it's actually a valid number of bytes written, and treats it as an error condition if not. `write_all()` now returns `Result` so the caller can check for the error; the print macros currently throw this away silently as I figured it wasn't a good idea for print to panic.