### PR TITLE
Add mechanism to properly open host stdio streams

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -27,7 +27,7 @@ pub fn get_stderr() -> isize {
 /// Open stdout and stderr.
 pub fn open_streams() -> Result<(),()> {
     // Special terminal path
-    let path = ":tt";
+    let path = ":tt\0";
 
     // To open stdin, use flag 0 instead of 4 or 8
     let stdout_fd = unsafe { syscall!(OPEN, path.as_bytes().as_ptr(), 4, path.len()) } as isize;

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,74 +13,76 @@ struct Stderr;
 /// Host's standard output
 struct Stdout;
 
-fn write_all(fd: usize, mut buffer: &[u8]) {
+fn write_all(fd: usize, mut buffer: &[u8]) -> Result<(),()> {
     while !buffer.is_empty() {
         match unsafe { syscall!(WRITE, fd, buffer.as_ptr(), buffer.len()) } {
             // Done
-            0 => return,
+            0 => return Ok(()),
             // `n` bytes were not written
-            n => {
+            n if n <= buffer.len() && n > 0 => {
                 let offset = (buffer.len() - n) as isize;
                 buffer = unsafe {
                     slice::from_raw_parts(buffer.as_ptr().offset(offset as isize), n)
-                }
-            }
+                };
+            },
+            // error writing bytes, most likely write() returned -1
+            _ => return Err(()),
         }
     }
+
+    Ok(())
 }
 
 impl Stderr {
-    fn write_all(&mut self, buffer: &[u8]) {
-        write_all(STDERR, buffer);
+    fn write_all(&mut self, buffer: &[u8]) -> Result<(),()> {
+        write_all(STDERR, buffer)
     }
 }
 
 impl Stdout {
-    fn write_all(&mut self, buffer: &[u8]) {
-        write_all(STDOUT, buffer);
+    fn write_all(&mut self, buffer: &[u8]) -> Result<(), ()> {
+        write_all(STDOUT, buffer)
     }
 }
 
 impl Write for Stderr {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.write_all(s.as_bytes());
-        Ok(())
+        self.write_all(s.as_bytes()).or(Err(fmt::Error))
     }
 }
 
 impl Write for Stdout {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.write_all(s.as_bytes());
-        Ok(())
+        self.write_all(s.as_bytes()).or(Err(fmt::Error))
     }
 }
 
 /// Write a `buffer` to the host's stderr
-pub fn ewrite(buffer: &[u8]) {
+pub fn ewrite(buffer: &[u8]) -> Result<(),()> {
     Stderr.write_all(buffer)
 }
 
 /// Write `fmt::Arguments` to the host's stderr
-pub fn ewrite_fmt(args: fmt::Arguments) {
-    Stderr.write_fmt(args).ok();
+pub fn ewrite_fmt(args: fmt::Arguments) -> fmt::Result {
+    Stderr.write_fmt(args)
 }
 
 /// Write a `string` to the host's stderr
-pub fn ewrite_str(string: &str) {
+pub fn ewrite_str(string: &str) -> Result<(),()> {
     Stderr.write_all(string.as_bytes())
 }
 
 /// Write a `buffer` to the host's stdout
-pub fn write(buffer: &[u8]) {
+pub fn write(buffer: &[u8]) ->Result<(),()> {
     Stdout.write_all(buffer)
 }
 
 /// Write `fmt::Arguments` to the host's stdout
-pub fn write_fmt(args: fmt::Arguments) {
-    Stdout.write_fmt(args).ok();
+pub fn write_fmt(args: fmt::Arguments) -> fmt::Result {
+    Stdout.write_fmt(args)
 }
 
 /// Write a `string` to the host's stdout
-pub fn write_str(string: &str) {
+pub fn write_str(string: &str) -> Result<(),()> {
     Stdout.write_all(string.as_bytes())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,16 @@
 //! extern crate cortex_m_semihosting;
 //!
 //! fn main() {
-//!     // File descriptor (on the host)
-//!     const STDOUT: usize = 1;
+//!     // Open streams on host
+//!     cortex_m_semihosting::open_streams().unwrap();
+//!     let stdout = cortex_m_semihosting::get_stdout();
 //!     static MSG: &'static [u8] = b"Hello, world!\n";
 //!
+//!     cortex_m_semihosting::io::write_all(stdout, MSG);
+//!
+//!     // Alternatively...
 //!     // Signature: fn write(fd: usize, ptr: *const u8, len: usize) -> usize
-//!     let r = unsafe { syscall!(WRITE, STDOUT, MSG.as_ptr(), MSG.len()) };
+//!     // let r = unsafe { syscall!(WRITE, cortex_m_semihosting::get_stdout(), MSG.as_ptr(), MSG.len()) };
 //!
 //!     // (Or you could have just written `hprintln!("Hello, world!")`)
 //!     // ..
@@ -114,6 +118,8 @@ mod macros;
 pub mod io;
 pub mod nr;
 pub mod debug;
+
+pub use io::{get_stdout, get_stderr, open_streams};
 
 /// Performs a semihosting operation, takes a pointer to an argument block
 #[inline(always)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,8 +31,8 @@ macro_rules! syscall1 {
 /// Macro for printing to the **host's** standard stderr
 #[macro_export]
 macro_rules! ehprint {
-    ($s:expr) => ($crate::io::ewrite_str($s));
-    ($($arg:tt)*) => ($crate::io::ewrite_fmt(format_args!($($arg)*)));
+    ($s:expr) => ($crate::io::ewrite_str($s).ok());
+    ($($arg:tt)*) => ($crate::io::ewrite_fmt(format_args!($($arg)*)).ok());
 }
 
 /// Macro for printing to the **host's** standard error, with a newline.
@@ -46,8 +46,8 @@ macro_rules! ehprintln {
 /// Macro for printing to the **host's** standard output
 #[macro_export]
 macro_rules! hprint {
-    ($s:expr) => ($crate::io::write_str($s));
-    ($($arg:tt)*) => ($crate::io::write_fmt(format_args!($($arg)*)));
+    ($s:expr) => ($crate::io::write_str($s).ok());
+    ($($arg:tt)*) => ($crate::io::write_fmt(format_args!($($arg)*)).ok());
 }
 
 /// Macro for printing to the **host's** standard output, with a newline.


### PR DESCRIPTION
This uses the OPEN semihosting syscall to open stdout/stderr properly instead of assuming their FDs and that they work. `pub fn open_streams()` is added to do this, and documented. `static mut` is used for the stream FDs because Cortex-M0 Rust doesn't have atomic types; `#[inline(never)]` accessors are used to force these to be accessed because stable Rust doesn't have volatile types.

This should be merged after PR #6; it contains the same commit as both touch the same area of the code.