### PR TITLE
add an opt-out "inline-asm" to make this compilable on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,21 @@ language: rust
 
 matrix:
   include:
-    - env: TARGET=thumbv7m-none-eabi
-      rust: nightly
+    - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
+    - env: TARGET=thumbv6m-none-eabi
+      rust: nightly
+      addons:
+        apt:
+          packages:
+            - gcc-arm-none-eabi
+    - env: TARGET=thumbv7m-none-eabi
+      rust: nightly
+      addons:
+        apt:
+          packages:
+            - gcc-arm-none-eabi
 
 before_install: set -e
 
@@ -24,8 +35,8 @@ before_cache:
 
 branches:
   only:
-    - auto
-    - try
+    - staging
+    - trying
 
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.1] - 2018-04-25
+
+### Added
+
+- An opt-out "inline-asm" Cargo feature. When this feature is disabled semihosting is implemented
+  using an external assembly file instead of using the unstable inline assembly (`asm!`) feature
+  meaning that this crate can be compiled on stable.
+
 ## [v0.2.0] - 2017-07-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ keywords = ["semihosting", "arm", "cortex-m"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-semihosting"
 repository = "https://github.com/japaric/cortex-m-semihosting"
-version = "0.2.0"
+version = "0.2.1"
 
-[dependencies]
+[build-dependencies]
+cc = "1.0.10"
+
+[features]
+inline-asm = []
+default = ["inline-asm"]

--- a/asm.s
+++ b/asm.s
@@ -1,0 +1,5 @@
+.global __syscall
+
+__syscall:
+  bkpt 0xAB
+  bx lr

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "continuous-integration/travis-ci/push",
+]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+extern crate cc;
+
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    if target.starts_with("thumbv") {
+        if env::var_os("CARGO_FEATURE_INLINE_ASM").is_none() {
+            cc::Build::new().file("asm.s").compile("asm");
+        }
+
+        println!("cargo:rustc-cfg=thumb");
+    }
+}

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,11 +1,8 @@
 set -euxo pipefail
 
 main() {
-    if [ $TARGET = thumbv7m-none-eabi ]; then
-        cargo install --list | grep xargo || \
-            cargo install xargo
-        rustup component list | grep 'rust-src.*installed' || \
-            rustup component add rust-src
+    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
+        rustup target add $TARGET
     fi
 }
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,14 +1,11 @@
 set -euxo pipefail
 
 main() {
-    local cargo=
-    if [ $TARGET = thumbv7m-none-eabi ]; then
-        cargo=xargo
-    else
-        cargo=cargo
-    fi
+    cargo check --target $TARGET --no-default-features
 
-    $cargo check --target $TARGET
+    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
+        cargo check --target $TARGET
+    fi
 }
 
 main


### PR DESCRIPTION
follow-up PR #17 swaps the defaults: stable by default; opting into `"inline-asm"` requires nightly.