### PR TITLE
add hprint macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.2] - 2018-11-04
+
+### Added
+
+- Added a family of `hprint` macros for printing to the host standard output /
+  error via globally shared `HStdout` / `HStderr` handles .
+
 ## [v0.3.1] - 2018-08-27
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-semihosting"
 readme = "README.md"
 repository = "https://github.com/japaric/cortex-m-semihosting"
-version = "0.3.1"
+version = "0.3.2"
 
 [features]
 inline-asm = []
+
+[dependencies]
+cortex-m = "0.5.8"

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,51 @@
+//! IMPLEMENTATION DETAILS USED BY MACROS
+
+use core::fmt::{self, Write};
+
+use cortex_m::interrupt;
+
+use hio::{self, HStderr, HStdout};
+
+static mut HSTDOUT: Option<HStdout> = None;
+
+pub fn hstdout_str(s: &str) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
+        if HSTDOUT.is_none() {
+            HSTDOUT = Some(hio::hstdout()?);
+        }
+
+        HSTDOUT.as_mut().unwrap().write_str(s).map_err(drop)
+    })
+}
+
+pub fn hstdout_fmt(args: fmt::Arguments) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
+        if HSTDOUT.is_none() {
+            HSTDOUT = Some(hio::hstdout()?);
+        }
+
+        HSTDOUT.as_mut().unwrap().write_fmt(args).map_err(drop)
+    })
+}
+
+static mut HSTDERR: Option<HStderr> = None;
+
+pub fn hstderr_str(s: &str) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
+        if HSTDERR.is_none() {
+            HSTDERR = Some(hio::hstderr()?);
+        }
+
+        HSTDERR.as_mut().unwrap().write_str(s).map_err(drop)
+    })
+}
+
+pub fn hstderr_fmt(args: fmt::Arguments) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
+        if HSTDERR.is_none() {
+            HSTDERR = Some(hio::hstderr()?);
+        }
+
+        HSTDERR.as_mut().unwrap().write_fmt(args).map_err(drop)
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,10 +147,14 @@
 #![deny(warnings)]
 #![no_std]
 
+extern crate cortex_m;
+
 #[macro_use]
 mod macros;
 
 pub mod debug;
+#[doc(hidden)]
+pub mod export;
 pub mod hio;
 pub mod nr;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,3 +27,61 @@ macro_rules! syscall1 {
         $crate::syscall1($crate::nr::$nr, $a1 as usize)
     };
 }
+
+/// Macro for printing to the HOST standard output
+///
+/// This macro returns a `Result<(), ()>` value
+#[macro_export]
+macro_rules! hprint {
+    ($s:expr) => {
+        $crate::export::hstdout_str($s)
+    };
+    ($($tt:tt)*) => {
+        $crate::export::hstdout_fmt(format_args!($($tt)*))
+    };
+}
+
+/// Macro for printing to the HOST standard output, with a newline.
+///
+/// This macro returns a `Result<(), ()>` value
+#[macro_export]
+macro_rules! hprintln {
+    () => {
+        $crate::export::hstdout_str("\n")
+    };
+    ($s:expr) => {
+        $crate::export::hstdout_str(concat!($s, "\n"))
+    };
+    ($s:expr, $($tt:tt)*) => {
+        $crate::export::hstdout_fmt(format_args!(concat!($s, "\n"), $($tt)*))
+    };
+}
+
+/// Macro for printing to the HOST standard error
+///
+/// This macro returns a `Result<(), ()>` value
+#[macro_export]
+macro_rules! heprint {
+    ($s:expr) => {
+        $crate::export::hstderr_str($s)
+    };
+    ($($tt:tt)*) => {
+        $crate::export::hstderr_fmt(format_args!($($tt)*))
+    };
+}
+
+/// Macro for printing to the HOST standard error, with a newline.
+///
+/// This macro returns a `Result<(), ()>` value
+#[macro_export]
+macro_rules! heprintln {
+    () => {
+        $crate::export::hstderr_str("\n")
+    };
+    ($s:expr) => {
+        $crate::export::hstderr_str(concat!($s, "\n"))
+    };
+    ($s:expr, $($tt:tt)*) => {
+        $crate::export::hstderr_fmt(format_args!(concat!($s, "\n"), $($tt)*))
+    };
+}


### PR DESCRIPTION
which are useful when using QEMU

the implementation uses unsafe `static mut` variables instead of safe `static` +
`interrupt::Mutex` to continue supporting Rust 1.30. `Mutex`'s const
constructor requires 1.31; moving to it would be a breaking change.

this PR also prepares a new release