### PR TITLE
Fix for JLink debuggers

### DIFF
--- a/src/hio.rs
+++ b/src/hio.rs
@@ -68,12 +68,14 @@ fn write_all(fd: usize, mut buffer: &[u8]) -> Result<(), ()> {
             // Done
             0 => return Ok(()),
             // `n` bytes were not written
-            n if n <= buffer.len() => {
+            n if n <= buffer.len() && n > 0 => {
                 let offset = (buffer.len() - n) as isize;
                 buffer = unsafe {
                     slice::from_raw_parts(buffer.as_ptr().offset(offset), n)
                 }
             }
+            // Error (-1) - should be an error but JLink can return -1
+            0xffffffff => return Ok(()),
             // Error
             _ => return Err(()),
         }


### PR DESCRIPTION
# Explanation

When sending 1 character it returns -1 from syscall. This fix mitigates the issue, but it not correct.
This is probably not the correct way to solve it (might be a bug in the JLink debugger firmware), but it currently solves the issue.

---

# To reproduce

JLink version info (this dev board https://www.decawave.com/product/dwm1001-development-board/):

```
Firmware: J-Link OB-STM32F072-128KB-CortexM compiled Jan  7 2019 14:08:04
Hardware: V1.00
```

Minimal example showing the problem:

```
#![no_main]
#![no_std]

// panic handler
extern crate panic_semihosting;
extern crate nrf52_hal_common;

use cortex_m_semihosting::hprint;
use cortex_m_rt::entry;

#[entry]
fn main() -> ! {
    hprint!("a").unwrap();

    loop{}
}
```