### PR TITLE
korken89's J-Link fix behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.3.4"
 
 [features]
 inline-asm = []
+jlink-quirks = []
 
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"

--- a/src/hio.rs
+++ b/src/hio.rs
@@ -74,6 +74,10 @@ fn write_all(fd: usize, mut buffer: &[u8]) -> Result<(), ()> {
                     slice::from_raw_parts(buffer.as_ptr().offset(offset), n)
                 }
             }
+            #[cfg(feature = "jlink-quirks")]
+            // Error (-1) - should be an error but JLink can return -1, -2, -3,...
+            // For good measure, we allow up to negative 15.
+            n if n > 0xfffffff0 => return Ok(()),
             // Error
             _ => return Err(()),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,13 @@
 //! When this feature is disabled semihosting is implemented using FFI calls into an external
 //! assembly file and compiling this crate works on stable and beta.
 //!
+//! ## `jlink-quirks`
+//!
+//! When this feature is enabled, return values above `0xfffffff0` from semihosting operation
+//! `SYS_WRITE` (0x05) are interpreted as if the entire buffer had been written. The current
+//! latest version 6.48b of J-Link exhibits such behaviour, causing a panic if this feature
+//! is not enabled.
+//!
 //! # Reference
 //!
 //! For documentation about the semihosting operations, check:


### PR DESCRIPTION
In response to https://github.com/rust-embedded/cortex-m-semihosting/issues/38 I suggest picking up https://github.com/rust-embedded/cortex-m-semihosting/pull/35 again.

@korken89 since you observed -1, -2, -3, maybe `n > 0xffff_fff0` is a good condition instead of catching just "-1"? As I understand it, worst case some very long outputs get truncated.

I did send an email to Segger support (would be good if these special cases were a finite list, and documented in UM08001), but who knows if they will answer :)