### PR TITLE
 Merge HStdout and HStderr into the same type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Merge `HStdout` and `HStderr` into one type: `HostStream`
+
 ## [v0.3.5] - 2019-08-29
 
 ### Added

--- a/src/export.rs
+++ b/src/export.rs
@@ -4,9 +4,9 @@ use core::fmt::{self, Write};
 
 use cortex_m::interrupt;
 
-use crate::hio::{self, HStderr, HStdout};
+use crate::hio::{self, HostStream};
 
-static mut HSTDOUT: Option<HStdout> = None;
+static mut HSTDOUT: Option<HostStream> = None;
 
 pub fn hstdout_str(s: &str) -> Result<(), ()> {
     interrupt::free(|_| unsafe {
@@ -28,7 +28,7 @@ pub fn hstdout_fmt(args: fmt::Arguments) -> Result<(), ()> {
     })
 }
 
-static mut HSTDERR: Option<HStderr> = None;
+static mut HSTDERR: Option<HostStream> = None;
 
 pub fn hstderr_str(s: &str) -> Result<(), ()> {
     interrupt::free(|_| unsafe {

--- a/src/hio.rs
+++ b/src/hio.rs
@@ -4,63 +4,45 @@ use core::{fmt, slice};
 use crate::nr;
 
 /// Host's standard error
+/// A byte stream to the host (e.g. host's stdout or stderr).
 #[derive(Clone, Copy)]
-pub struct HStderr {
+pub struct HostStream {
     fd: usize,
 }
 
-impl HStderr {
+impl HostStream {
     /// Attempts to write an entire `buffer` into this sink
     pub fn write_all(&mut self, buffer: &[u8]) -> Result<(), ()> {
         write_all(self.fd, buffer)
     }
 }
 
-impl fmt::Write for HStderr {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.write_all(s.as_bytes()).map_err(|_| fmt::Error)
-    }
-}
-
-/// Host's standard output
-#[derive(Clone, Copy)]
-pub struct HStdout {
-    fd: usize,
-}
-
-impl HStdout {
-    /// Attempts to write an entire `buffer` into this sink
-    pub fn write_all(&mut self, buffer: &[u8]) -> Result<(), ()> {
-        write_all(self.fd, buffer)
-    }
-}
-
-impl fmt::Write for HStdout {
+impl fmt::Write for HostStream {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.write_all(s.as_bytes()).map_err(|_| fmt::Error)
     }
 }
 
 /// Construct a new handle to the host's standard error.
-pub fn hstderr() -> Result<HStderr, ()> {
+pub fn hstderr() -> Result<HostStream, ()> {
     // There is actually no stderr access in ARM Semihosting documentation. Use
     // convention used in libgloss.
     // See: libgloss/arm/syscalls.c, line 139.
     // https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=libgloss/arm/syscalls.c#l139
-    open(":tt\0", nr::open::W_APPEND).map(|fd| HStderr { fd })
+    open(":tt\0", nr::open::W_APPEND)
 }
 
 /// Construct a new handle to the host's standard output.
-pub fn hstdout() -> Result<HStdout, ()> {
-    open(":tt\0", nr::open::W_TRUNC).map(|fd| HStdout { fd })
+pub fn hstdout() -> Result<HostStream, ()> {
+    open(":tt\0", nr::open::W_TRUNC)
 }
 
-fn open(name: &str, mode: usize) -> Result<usize, ()> {
+fn open(name: &str, mode: usize) -> Result<HostStream, ()> {
     let name = name.as_bytes();
     match unsafe { syscall!(OPEN, name.as_ptr(), mode, name.len() - 1) } as
         isize {
         -1 => Err(()),
-        fd => Ok(fd as usize),
+        fd => Ok(HostStream { fd: fd as usize}),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,7 @@
 //!
 //! // This function will be called by the application
 //! fn print() -> Result<(), core::fmt::Error> {
-//!     let mut stdout = match hio::hstdout() {
-//!         Ok(fd) => fd,
-//!         Err(()) => return Err(core::fmt::Error),
-//!     };
+//!     let mut stdout = hio::hstdout().map_err(|_| core::fmt::Error)?;
 //!
 //!     let language = "Rust";
 //!     let ranking = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! # Example
 //!
-//! ## Using `hio::HStdout`
+//! ## Using `hio::hstdout`
 //!
 //! This example will demonstrate how to print formatted strings.
 //!


### PR DESCRIPTION
They were exactly the same anyway. Now it is easier to pass either
stdout or stderr to a function, for example.