### PR TITLE
Actually use heprintln, and unwrap it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Adds a feature to work around JLink quirks
 - Adds a dbg! macro using heprintln
+- Now Rust 2018 edition
 
 ## [v0.3.4] - 2019-04-22
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,8 @@
 //! `dbg!` returns a given expression and prints it using `heprintln!` including context
 //! for quick and dirty debugging.
 //!
+//! Panics if `heprintln!` returns an error.
+//!
 //! Example:
 //!
 //! ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -88,19 +88,20 @@ macro_rules! heprintln {
 
 /// Macro that prints and returns the value of a given expression
 /// for quick and dirty debugging. Works exactly like `dbg!` in
-/// the standard library, replacing `eprintln` with `heprintln`.
+/// the standard library, replacing `eprintln` with `heprintln`,
+/// which it unwraps.
 #[macro_export]
 macro_rules! dbg {
     () => {
-        $crate::hprintln!("[{}:{}]", file!(), line!());
+        $crate::heprintln!("[{}:{}]", file!(), line!()).unwrap();
     };
     ($val:expr) => {
         // Use of `match` here is intentional because it affects the lifetimes
         // of temporaries - https://stackoverflow.com/a/48732525/1063961
         match $val {
             tmp => {
-                $crate::hprintln!("[{}:{}] {} = {:#?}",
-                    file!(), line!(), stringify!($val), &tmp);
+                $crate::heprintln!("[{}:{}] {} = {:#?}",
+                    file!(), line!(), stringify!($val), &tmp).unwrap();
                 tmp
             }
         }


### PR DESCRIPTION
I'm sorry, it's me again...

- std::dbg panics on failure, given `dbg!` is advertised as "quick n' dirty" I think this behaviour makes sense here too (no need to type `.unwrap()` everywhere, no unused Result warnings)
- also to be more analogous, actually use `heprintln` (as already advertised in documentation)
- I went ahead and added the nod to 2018 edition missing last time