### PR TITLE
Remove #[deny(warnings)]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: rust
 
+env:
+  global:
+    - RUSTFLAGS="-D warnings"
+
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,6 @@
 
 #![cfg_attr(feature = "inline-asm", feature(asm))]
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
`#[deny(warnings)]` is considered an [anti-pattern](https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md).