### PR TITLE
Add `no-semihosting` feature to suppress all semihosting calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 [features]
 inline-asm = []
 jlink-quirks = []
+no-semihosting = []
 
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"


### PR DESCRIPTION
I must not be the only one who indulges in semihosting for quick print-debugging and then has a trail of intermediate mess...

With this new feature, one can easily patch out all these calls in the application (by additivity of cargo features), and get a binary that runs without debugger attached.