### PR TITLE
Prepare v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.7] - 2020-12-02
+
+- Replaces the yanked v0.3.6 by reverting #48, so the semihosting macros
+  continue to return a Result.
+
 ## [v0.3.6] - 2020-12-01
+
+v0.3.6 was yanked because it incorrectly included #48, which was a breaking
+change.
 
 ### Added
 
@@ -116,7 +124,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.6...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.7...HEAD
+[v0.3.7]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.6...v0.3.7
 [v0.3.6]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.5...v0.3.6
 [v0.3.5]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.4...v0.3.5
 [v0.3.4]: https://github.com/rust-embedded/cortex-m-semihosting/compare/v0.3.3...v0.3.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-semihosting"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m-semihosting"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2018"
 
 [features]

--- a/src/export.rs
+++ b/src/export.rs
@@ -8,44 +8,44 @@ use crate::hio::{self, HStderr, HStdout};
 
 static mut HSTDOUT: Option<HStdout> = None;
 
-pub fn hstdout_str(s: &str) {
-    let _result = interrupt::free(|_| unsafe {
+pub fn hstdout_str(s: &str) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
         if HSTDOUT.is_none() {
             HSTDOUT = Some(hio::hstdout()?);
         }
 
         HSTDOUT.as_mut().unwrap().write_str(s).map_err(drop)
-    });
+    })
 }
 
-pub fn hstdout_fmt(args: fmt::Arguments) {
-    let _result = interrupt::free(|_| unsafe {
+pub fn hstdout_fmt(args: fmt::Arguments) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
         if HSTDOUT.is_none() {
             HSTDOUT = Some(hio::hstdout()?);
         }
 
         HSTDOUT.as_mut().unwrap().write_fmt(args).map_err(drop)
-    });
+    })
 }
 
 static mut HSTDERR: Option<HStderr> = None;
 
-pub fn hstderr_str(s: &str) {
-    let _result = interrupt::free(|_| unsafe {
+pub fn hstderr_str(s: &str) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
         if HSTDERR.is_none() {
             HSTDERR = Some(hio::hstderr()?);
         }
 
         HSTDERR.as_mut().unwrap().write_str(s).map_err(drop)
-    });
+    })
 }
 
-pub fn hstderr_fmt(args: fmt::Arguments) {
-    let _result = interrupt::free(|_| unsafe {
+pub fn hstderr_fmt(args: fmt::Arguments) -> Result<(), ()> {
+    interrupt::free(|_| unsafe {
         if HSTDERR.is_none() {
             HSTDERR = Some(hio::hstderr()?);
         }
 
         HSTDERR.as_mut().unwrap().write_fmt(args).map_err(drop)
-    });
+    })
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! syscall {
     };
 }
 
-/// Macro version of `syscall1`.
+/// Macro version of `syscall1`
 #[macro_export]
 macro_rules! syscall1 {
     ($nr:ident, $a1:expr) => {
@@ -28,10 +28,9 @@ macro_rules! syscall1 {
     };
 }
 
-/// Macro for printing to the HOST standard output.
+/// Macro for printing to the HOST standard output
 ///
-/// This is similar to the `print!` macro in the standard library. Both will panic on any failure to
-/// print.
+/// This macro returns a `Result<(), ()>` value
 #[macro_export]
 macro_rules! hprint {
     ($s:expr) => {
@@ -44,8 +43,7 @@ macro_rules! hprint {
 
 /// Macro for printing to the HOST standard output, with a newline.
 ///
-/// This is similar to the `println!` macro in the standard library. Both will panic on any failure to
-/// print.
+/// This macro returns a `Result<(), ()>` value
 #[macro_export]
 macro_rules! hprintln {
     () => {
@@ -59,10 +57,9 @@ macro_rules! hprintln {
     };
 }
 
-/// Macro for printing to the HOST standard error.
+/// Macro for printing to the HOST standard error
 ///
-/// This is similar to the `eprint!` macro in the standard library. Both will panic on any failure
-/// to print.
+/// This macro returns a `Result<(), ()>` value
 #[macro_export]
 macro_rules! heprint {
     ($s:expr) => {
@@ -75,8 +72,7 @@ macro_rules! heprint {
 
 /// Macro for printing to the HOST standard error, with a newline.
 ///
-/// This is similar to the `eprintln!` macro in the standard library. Both will panic on any failure
-/// to print.
+/// This macro returns a `Result<(), ()>` value
 #[macro_export]
 macro_rules! heprintln {
     () => {
@@ -90,15 +86,14 @@ macro_rules! heprintln {
     };
 }
 
-/// Macro that prints and returns the value of a given expression for quick and
-/// dirty debugging.
-///
-/// Works exactly like `dbg!` in the standard library, replacing `eprintln!`
-/// with `heprintln!`.
+/// Macro that prints and returns the value of a given expression
+/// for quick and dirty debugging. Works exactly like `dbg!` in
+/// the standard library, replacing `eprintln` with `heprintln`,
+/// which it unwraps.
 #[macro_export]
 macro_rules! dbg {
     () => {
-        $crate::heprintln!("[{}:{}]", file!(), line!());
+        $crate::heprintln!("[{}:{}]", file!(), line!()).unwrap();
     };
     ($val:expr) => {
         // Use of `match` here is intentional because it affects the lifetimes
@@ -106,7 +101,7 @@ macro_rules! dbg {
         match $val {
             tmp => {
                 $crate::heprintln!("[{}:{}] {} = {:#?}",
-                    file!(), line!(), stringify!($val), &tmp);
+                    file!(), line!(), stringify!($val), &tmp).unwrap();
                 tmp
             }
         }


### PR DESCRIPTION
This PR reverts #48 in master, allowing 0.3.7 to support cortex-m 0.7 while being a non-breaking-change to 0.3.5.

As previously I'll copy these CHANGELOG entries over to cortex-m afterwards.